### PR TITLE
Update system Java for cypher-shell

### DIFF
--- a/gfe-db/database/Makefile
+++ b/gfe-db/database/Makefile
@@ -90,12 +90,9 @@ service.backup:
 		--comment "${STAGE}=${APP_NAME} backup service" 2>&1 | tee -a $$CFN_LOG_PATH || true
 
 service.backup.list:
-	@aws s3 ls --recursive s3://${DATA_BUCKET_NAME}/backups/neo4j/ | cut -d' ' -f7 | cut -d'/' -f3-6
+	@echo "Select a backup using the format YYYY/MM/DD/HH:"
+	@aws s3 ls --recursive --human-readable s3://${DATA_BUCKET_NAME}/backups/neo4j/
 
-# TODO add confirmation with prequisites (warnings to avoid losing data, make sure scripts are synced etc.) ✅
-# TODO database restore: validate date parameter is given ✅ and in the correct format ✅
-# TODO move validation to the database/Makefile ✅
-# TODO database restore: validate that the backup exists ✅
 service.restore: #from_date=<YYYY/MM/DD/HH>
 	@[ "$$from_date" != "" ] || (echo "from_date is required" && exit 1) && \
 	[ "$$(echo "$$from_date" | grep -E '^[0-9]{4}/[0-9]{2}/[0-9]{2}/[0-9]{2}$$')" ] || (echo "from_date must be in the format YYYY/MM/DD/HH" && exit 1) && \

--- a/gfe-db/database/scripts/load_db.sh
+++ b/gfe-db/database/scripts/load_db.sh
@@ -42,11 +42,6 @@ NEO4J_USERNAME=$(echo $NEO4J_CREDENTIALS | jq -r '.NEO4J_USERNAME')
 NEO4J_PASSWORD=$(echo $NEO4J_CREDENTIALS | jq -r '.NEO4J_PASSWORD')
 
 # Get data bucket name
-DATA_BUCKET_NAME=$(aws ssm get-parameters \
-    --region $(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/\(.*\)[a-z]/\1/') \
-    --names "/${APP_NAME}/${STAGE}/${AWS_REGION}/DataBucketName" \
-    | jq -r '.Parameters[0].Value')
-
 if [[ -z $DATA_BUCKET_NAME ]]; then
     echo "$(date -u +'%Y-%m-%d %H:%M:%S.%3N') - S3 bucket not found."
     exit 1
@@ -71,6 +66,8 @@ echo "****** Begin Cypher ******"
 printf "$(cat $NEO4J_CYPHER_PATH/tmp/$RELEASE/load.$RELEASE.cyp)\n"
 echo "****** End Cypher ******"
 
+# TODO fix error caused by Java version:
+# Unsupported Java 11.0.18 detected. Please use Oracle(R) Java(TM) 17, OpenJDK(TM) 17 to run Cypher Shell.
 # Run Cypher load query
 echo "$(date -u +'%Y-%m-%d %H:%M:%S.%3N') - Loading data for release $RELEASE into Neo4j..."
 cat $NEO4J_CYPHER_PATH/tmp/$RELEASE/load.$RELEASE.cyp | \

--- a/gfe-db/database/template.yaml
+++ b/gfe-db/database/template.yaml
@@ -159,7 +159,12 @@ Resources:
           python3-setuptools \
           certbot \
           git \
-          python3-pip
+          python3-pip \
+          openjdk-17-jdk \
+          openjdk-17-jre
+          # Update system Java for Neo4j cypher-shell
+          update-java-alternatives --set /usr/lib/jvm/java-1.17.0-openjdk-amd64
+          /usr/bin/java -version
           export BITNAMI_HOME=/home/bitnami
           # CloudWatch Logs Agent
           mkdir -p /tmp/amazon-cloudwatch-agent


### PR DESCRIPTION
## Description
Loading alleles broke after upgrading to Neo4j 5.5.0 because Systems Manager Run Command used the system Java version instead of the Bitnami version. Fixed by upgrading the system Java version to the same version as the Bitnami version in the user data.

## Next Tasks
* Implement consistency check using neo4j-admin
* Backup data from Neo4j 4.4.0 and restore to 5.5.0